### PR TITLE
8 document encoding

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,11 @@ Almost too much to list:
 
 ## Changes
 
+### 0.4.11 (January 12, 2019)
+- handle files encoded in Windows 1252
+- fix for duplicate col_b_transfers_from_affiliated mapping
+- allow for form F4T
+
 ### 0.4.10 (November 7, 2018)
 - strip whitespace when parsing values as float or date
 - fix mis-mapped field in paper F3 filings

--- a/docs/index.md
+++ b/docs/index.md
@@ -195,6 +195,11 @@ Almost too much to list:
 
 ## Changes
 
+### 0.4.11 (January 12, 2019)
+- handle files encoded in Windows 1252
+- fix for duplicate col_b_transfers_from_affiliated mapping
+- allow for form F4T
+
 ### 0.4.10 (November 7, 2018)
 - strip whitespace when parsing values as float or date
 - fix mis-mapped field in paper F3 filings

--- a/fecfile/__init__.py
+++ b/fecfile/__init__.py
@@ -68,9 +68,13 @@ def from_file(file_path):
     a ``str`` of the path to the file, and returns the parsed Python object.
     """
     parsed = {}
-    with open(file_path) as file:
-        unparsed = file.read()
-        parsed = fecparser.loads(unparsed)
+    try:
+        with open(file_path, 'r') as file:
+            unparsed = file.read()
+    except UnicodeDecodeError:
+        with open(file_path, 'r', encoding='ISO-8859-1') as file:
+            unparsed = file.read()
+    parsed = fecparser.loads(unparsed)
     return parsed
 
 

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ requirements = [
 
 setup(
     name='fecfile',
-    version='0.4.10',
+    version='0.4.11',
     description='a python parser for the .fec file format',
     long_description=long_description,
     long_description_content_type="text/markdown",

--- a/test-data/1260488.fec
+++ b/test-data/1260488.fec
@@ -1,0 +1,45 @@
+HDRFEC8.3FECfile8.3.0.0(f32)
+F99C00412569DENTON COUNTY REPUBLICAN VICTORY FUND2921 Country Club Rd #102DentonTX76202JohnsonJamesS.20180907MST
+[BEGINTEXT]
+DENTON COUNTY REPUBLICAN VICTORY FUND
+2921 Country Club Road
+Suite 102
+Denton, TX 76210
+ 
+September 7, 2018
+ 
+Romy Adame-Wilson
+Senior Campaign Finance Analyst
+Reports Analysis Division
+Federal Election Commission
+Washington, DC 20463
+ 
+Dear Ms. Adame-Wilson:
+ 
+Denton County Republican Party Victory Fund is responding to your request for additional information dated August 30, 2018, regarding reporting in our Amended May Monthly (4/1/18-4/30/18) of an increase in disbursements totaling $29,390.11 from the amounts disclosed on our original report for May Monthly (4/1/18-4/30/18).  
+ 
+In response to RFAI dated 08/30/2018:
+ 
+Denton County Republican Victory Fund [in its Amended May Monthly (4/1/18-4/30/18)] reported an increase in disbursements totaling $29,390.11 from the amounts disclosed on our original report because a post-filing review by the Denton County Republican Party’s newly appointed First Vice Chair - Finance identified the following clerical mistakes / omissions from the originally filed report:
+Amount         Payee                                             Date
+ $ 25,204.32 Embassy Suites                            4/10/18
+      1,450.12 Embassy Suites                            4/30/18
+         847.76 Oakmont Country Club                  4/24/18
+         400.00 Highland Village Lion's Club          4/4/18
+         300.00 Lifeline Church                              4/2/18
+         275.81 Frontier Communications               4/19/18
+         250.00 Lakeland Baptist Church              4/5/18
+         219.37 Air By Phariss                                4/24/18
+         200.00 Town of Flower Mound                 4/4/18
+         112.61 Cytracom                                       4/25/18
+           80.12 North Texas Printing Solutions      4/30/18
+           50.00 US Postal Service                         4/26/18
+ $ 29,390.11
+
+Those omissions were inadvertent reporting mistakes attributable to transition of clerical employees at the time of the original report. In response, Denton County Republican Victory Fund has implemented new administration processes and executive review, including additional reconciliation procedures, to strengthen internal controls and to provide assurance that such omissions will not recur.
+ 
+Respectfully submitted by,
+James S. Johnson
+First Vice Chair – Finance, Denton County Republican Party, and
+Treasurer, Denton County Republican Party Victory Fund
+[ENDTEXT]

--- a/tests.py
+++ b/tests.py
@@ -249,6 +249,14 @@ class V1Filing(unittest.TestCase):
         self.assertEqual(sched_b[0]['expenditure_amount'], 286.61)
 
 
+class Windows1252Encoding(unittest.TestCase):
+    def test_read(self):
+        file_path = 'test-data/1260488.fec'
+        parsed = fecfile.from_file(file_path)
+        self.assertIsInstance(parsed['filing']['date_signed'], datetime)
+        self.assertEqual(parsed['filing']['city'], 'Denton')
+
+
 class AllFormsHaveMappings(unittest.TestCase):
     def test_request(self):
         missing_mappings = {}
@@ -293,6 +301,7 @@ if __name__ == '__main__':
         CommaInCSVFiling('test_request'),
         V2Filing('test_request'),
         V1Filing('test_request'),
+        Windows1252Encoding('test_read'),
     ])
     mappings_test = unittest.TestSuite([AllFormsHaveMappings('test_request')])
     if len(sys.argv) > 1 and sys.argv[1] == 'mappings':


### PR DESCRIPTION
* **Please check if the PR includes the following**
- [x] Tests for the changes have been added (if applicable)
- [x] Docs have been added / updated (if applicable)

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

provides a fix for #8 

* **What is the current behavior?** (You can also link to an open issue here)

Files encoded as Windows 1252 throw an unhandled exception when parsed by `from_file`.

* **What is the new behavior (if this is a feature change)?**

Files encoded as Windows 1252 are parsed correctly.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No.

* **Other information**:
