### PR TITLE
Perf increase

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,37 @@
+# This is a comment.
+# Each line is a file pattern followed by one or more owners.
+
+# These owners will be the default owners for everything in
+# the repo. Unless a later match takes precedence,
+# @global-owner1 and @global-owner2 will be requested for
+# review when someone opens a pull request.
+*       @washingtonpost/news-engineering
+
+# Order is important; the last matching pattern takes the most
+# precedence. When someone opens a pull request that only
+# modifies JS files, only @js-owner and not the global
+# owner(s) will be requested for a review.
+# *.js    @js-owner
+
+# You can also use email addresses if you prefer. They'll be
+# used to look up users just like we do for commit author
+# emails.
+# *.go docs@example.com
+
+# In this example, @doctocat owns any files in the build/logs
+# directory at the root of the repository and any of its
+# subdirectories.
+# /build/logs/ @doctocat
+
+# The `docs/*` pattern will match files like
+# `docs/getting-started.md` but not further nested files like
+# `docs/build-app/troubleshooting.md`.
+# docs/*  docs@example.com
+
+# In this example, @octocat owns any file in an apps directory
+# anywhere in your repository.
+# apps/ @octocat
+
+# In this example, @doctocat owns any file in the `/docs`
+# directory in the root of your repository.
+# /docs/ @doctocat

--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ Schedule C and Schedule D itemizations. Also, passing
 ``{'filter_itemizations': []}`` to ``options`` will result in only the header
 and the filing being parsed and returned.
 
-Including `{'as_strings': True}` in the `options` dictionary will not attempt to convert values that are normally numeric or datetimes to their native python types and will return dictionaries with all values as strings.
+Including `{'as_strings': True}` in the `options` dictionary will not attempt to convert values that are normally numeric or datetimes to their native python types and will return dictionaries with all values as strings. Including `{'simple_conversion': True}` will bypass int conversion and convert datetimes to strings that look like `YYYY-MM-DD` (from `YYYYMMDD`), which speeds up conversion significantly.
 
 <h3 id="fecfile.parse_header">parse_header</h3>
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # fecfile
-A python parser for the .fec file format
+A python parser for the .fec file format.
 
 This is a library for converting campaign finance filings stored in the .fec format into native python objects. It maps the comma/ASCII 28 delimited fields to canonical names based on the version the filing uses and then converts the values that are dates and numbers into the appropriate `int`, `float`, or `datetime` objects.
 

--- a/fecfile/cache.py
+++ b/fecfile/cache.py
@@ -4,7 +4,6 @@ import re
 MAPPING_CACHE_KEY = "%s:%s"
 MAPPING_CACHE = {}
 
-TYPE_CACHE_KEY = "%s:%s:%s"
 TYPE_CACHE = {}
 
 
@@ -39,12 +38,12 @@ def getMapping_from_regex(mappings, form, version):
 
 def getMapping(mappings, form, version):
     """ Tries to find the mapping from cache before looking it up w regex """
-    key = MAPPING_CACHE_KEY % (form, version)
-    try:
-        mapping = MAPPING_CACHE[key]
-    except KeyError:
-        mapping = getMapping_from_regex(mappings, form, version)
-        MAPPING_CACHE[key] = mapping
+    key = (form, version)
+    if key in MAPPING_CACHE:
+        return MAPPING_CACHE[key]
+
+    mapping = getMapping_from_regex(mappings, form, version)
+    MAPPING_CACHE[key] = mapping
     return mapping
 
 

--- a/fecfile/cache.py
+++ b/fecfile/cache.py
@@ -41,7 +41,6 @@ def getMapping(mappings, form, version):
     key = (form, version)
     if key in MAPPING_CACHE:
         return MAPPING_CACHE[key]
-
     mapping = getMapping_from_regex(mappings, form, version)
     MAPPING_CACHE[key] = mapping
     return mapping

--- a/fecfile/cache.py
+++ b/fecfile/cache.py
@@ -10,6 +10,7 @@ TYPE_CACHE = {}
 
 class FecParserMissingMappingError(Exception):
     """when a line in an FEC filing doesn't have a form/version mapping"""
+
     def __init__(self, opts, msg=None):
         if msg is None:
             msg = ('cannot parse version {v} of form {f} - '
@@ -65,10 +66,9 @@ def getTypeMapping_from_regex(types, form, version, field):
 
 def getTypeMapping(types, form, version, field):
     """ caches the mapping to dict """
-    key = TYPE_CACHE_KEY % (form, version, field)
-    try:
-        mapping = TYPE_CACHE[key]
-    except KeyError:
-        mapping = getTypeMapping_from_regex(types, form, version, field)
-        TYPE_CACHE[key] = mapping
+    key = (form, version, field)
+    if key in TYPE_CACHE:
+        return TYPE_CACHE[key]
+    mapping = getTypeMapping_from_regex(types, form, version, field)
+    TYPE_CACHE[key] = mapping
     return mapping

--- a/fecfile/fecparser.py
+++ b/fecfile/fecparser.py
@@ -7,6 +7,8 @@ import warnings
 
 from .cache import getTypeMapping, getMapping
 
+COLUMN_SEPARATOR = chr(0x1c)
+
 
 class FecParserTypeWarning(UserWarning):
     """when data in an FEC filing doesn't match types.json"""
@@ -75,7 +77,8 @@ def iter_lines(lines, options={}):
     for line_unk in lines:
         current_line_num += 1
         try:
-            line = line_unk if type(line_unk) is str else line_unk.decode('utf-8')
+            line = line_unk if type(
+                line_unk) is str else line_unk.decode('utf-8')
         except UnicodeDecodeError:
             line = line_unk.decode('ISO-8859-1')
         if version is None:
@@ -102,7 +105,8 @@ def iter_lines(lines, options={}):
                     f99_text += '\n' + line
                 continue
             as_strings = options.get('as_strings', False)
-            parsed = parse_line(line, version, current_line_num, as_strings)
+            simple_conversion = options.get('simple_conversion', False)
+            parsed = parse_line(line, version, current_line_num, as_strings, simple_conversion)
             if parsed is None:
                 continue
             if summary:
@@ -116,13 +120,13 @@ def iter_lines(lines, options={}):
 
 
 def fields_from_line(line, use_ascii_28=False):
-    if (chr(0x1c) in line) or use_ascii_28:
-        fields = line.split(chr(0x1c))
+    if (COLUMN_SEPARATOR in line) or use_ascii_28:
+        fields = line.split(COLUMN_SEPARATOR)
     else:
         reader = csv.reader([line])
         fields = next(reader)
     for i, field in enumerate(fields):
-        # Unquote quoted fields
+        # Remove quotes from quoted fields
         if field and field[0] == '"' and field[-1] == '"':
             fields[i] = field[1:-1]
     return fields
@@ -159,7 +163,7 @@ def parse_header(lines):
     return parsed, fields[1], 1
 
 
-def parse_line(line, version, line_num=None, as_strings=False):
+def parse_line(line, version, line_num=None, as_strings=False, simple_conversion=False):
     ascii_separator = True
     if version is None or version[0] in comma_versions:
         ascii_separator = False
@@ -175,18 +179,23 @@ def parse_line(line, version, line_num=None, as_strings=False):
         if as_strings:
             out[k] = val
         else:
-            out[k] = getTyped(form, version, k, val, line_num)
+            out[k] = getTyped(form, version, k, val, line_num, simple_conversion)
     return out
 
 
-nones = ['none', 'n/a']
+nones = set(['none', 'n/a'])
 
 
-def getTyped(form, version, field, value, line_num):
+def getTyped(form, version, field, value, line_num, simple_conversion=False):
+    # If simple_conversion is True, don't convert integers (which should have
+    # same string representation) and convert dates (which always look like
+    # YYYYMMDD) into strings that look like YYYY-MM-DD
     prop = getTypeMapping(types, form, version, field)
     if prop:
         try:
             if prop['type'] == 'integer':
+                if simple_conversion:
+                    return value
                 return int(value)
             if prop['type'] == 'float':
                 stripped = value.strip()
@@ -195,10 +204,15 @@ def getTyped(form, version, field, value, line_num):
                 sanitized = stripped.replace('%', '')
                 return float(sanitized)
             if prop['type'] == 'date':
-                format = prop['format']
                 stripped = value.strip()
                 if stripped == '':
                     return None
+
+                if simple_conversion:
+                    # Add hyphens to the date
+                    return stripped[0:4] + '-' + stripped[4:6] + '-' + stripped[6:8]
+
+                format = prop["format"]
                 parsed_date = datetime.strptime(
                     stripped,
                     format)

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,6 @@
+autopep8
+pylint
+pytest
+pytest-cov
+pycodestyle
+tox

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,8 @@
+[bdist_wheel]
+universal = 1
+
+[pycodestyle]
+max-line-length = 160
+
+[aliases]
+test = pytest

--- a/setup.py
+++ b/setup.py
@@ -1,28 +1,35 @@
 from setuptools import setup, find_packages
 
-
+LONG_DESCRIPTION = ''
 with open('README.md', 'r') as file:
-    long_description = '\n'.join(file.readlines()[3:])
+    LONG_DESCRIPTION = '\n'.join(file.readlines()[3:])
 
-
-requirements = [
+INSTALL_REQUIRES = (
     'pytz>=2018.4',
-    'requests>=2.19.1',
-    ]
+    'requests<3'
+)
+
+PROJECT = 'wapo-fec'
+AUTHOR = 'The Washington Post Newsroom Engineering Team'
+COPYRIGHT = '2021, {}'.format(AUTHOR)
+
+# The full version, including alpha/beta/rc tags
+RELEASE = '0.0.2'
+# The short X.Y version
+VERSION = '.'.join(RELEASE.split('.')[:2])
 
 
 setup(
-    name='fecfile',
-    version='0.6.4',
+    name=PROJECT,
+    version=RELEASE,
     description='a python parser for the .fec file format',
-    long_description=long_description,
+    long_description=LONG_DESCRIPTION,
     long_description_content_type="text/markdown",
-    url='https://esonderegger.github.io/fecfile/',
     project_urls={
-        'Bug Tracker': 'https://github.com/esonderegger/fecfile/issues',
-        'Source Code': 'https://github.com/esonderegger/fecfile/',
+        'Bug Tracker': 'https://github.com/washingtonpost/fecfile/issues',
+        'Source Code': 'https://github.com/washingtonpost/fecfile/',
     },
-    author='Evan Sonderegger',
+    author=AUTHOR,
     author_email='evan@rpy.xyz',
     license='Apache License 2.0',
     keywords='fec campaign finance politics',
@@ -36,6 +43,6 @@ setup(
     ],
     packages=find_packages(exclude=['docs', 'test-data']),
     package_data={'fecfile': ['mappings.json', 'types.json']},
-    install_requires=requirements,
+    install_requires=INSTALL_REQUIRES,
     zip_safe=False,
-    )
+)

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,6 @@ setup(
         'Source Code': 'https://github.com/washingtonpost/fecfile/',
     },
     author=AUTHOR,
-    author_email='evan@rpy.xyz',
     license='Apache License 2.0',
     keywords='fec campaign finance politics',
     classifiers=[


### PR DESCRIPTION
Patch in changes for increasing the performance of the FEC file parser.

- refactored date parsing to not actually localize and parse the times (always in same YYYYMMDD format) (⚡⚡)
- refactored the way cache keys are computed to be faster (⚡)
- initialized the character `chr(0x1c)` outside of the function to save a tiny slice of time (🙂)
- refactored out slow startsWith calls with string indexing and character comparisons (⚡⚡)
- found a completely redundant function call that was taking time for each line (⚡⚡)
- refactored `nones` to be a set rather than a list for faster membership checking (⚡)

Ensured the unit tests still pass. To enable faster date parsing, include `{'simple_conversion': True}` in the options to bypass int conversion and convert datetimes to strings that look like `YYYY-MM-DD` (from `YYYYMMDD`), which speeds up conversion significantly.