### PR TITLE
Updates mappings f3z1 and f3z2 for version 8.4

### DIFF
--- a/fecfile/mappings.json
+++ b/fecfile/mappings.json
@@ -5162,7 +5162,7 @@
     ]
   },
   "^f3z1": {
-    "^(P3.4|8.3|8.2)": [
+    "^(P3.4|8.4|8.3|8.2)": [
       "form_type",
       "filer_committee_id_number",
       "principal_committee_name",
@@ -5202,7 +5202,7 @@
     ]
   },
   "^f3z2": {
-    "^(P3.4|8.3|8.2)": [
+    "^(P3.4|8.4|8.3|8.2)": [
       "form_type",
       "filer_committee_id_number",
       "principal_committee_name",


### PR DESCRIPTION
* **Please check if the PR includes the following**
- [x] Tests for the changes have been added (if applicable)
- [x] Docs have been added / updated (if applicable)

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
This updates the mappings for FEC forms F3Z1 and F3Z2 to version 8.4. 


* **What is the current behavior?** (You can also link to an open issue here)
Currently, `fecfile.loads()`will throw an error when attempting to parse FEC F3Z1 and F3Z2 filings because the mapping isn't specified. 

```
FecParserMissingMappingError: cannot parse version 8.4 of form F3Z1 - no mapping found
```

You can test this behavior on FEC filing no. [1611708](https://docquery.fec.gov/dcdev/posted/1611708.fec).

* **What is the new behavior (if this is a feature change)?**
I consulted Derek Willis' [sources](https://github.com/dwillis/fech-sources/tree/5e1cd8a1039e35208d40ed1e7040239e0e2ce152) in his `fech` fork to confirm that the 8.3 mappings for these files are the same as the 8.4. I then bumped the versions for those two forms in mappings.json. I've tested this locally, and fecfile.loads() will now parse F3Z1 filings. 

I have not tested it on a F3Z2 filing because I don't have one readily available but made the change based on Derek's files.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
This doesn't introduce a breaking change.


* **Other information**:
