### PR TITLE
update to fec 8.5

### DIFF
--- a/fecfile/mappings.json
+++ b/fecfile/mappings.json
@@ -419,7 +419,7 @@
       "bank_zip_code",
       "beginning_image_number"
     ],
-    "^8.4": [
+    "^8.5|8.4": [
       "form_type",
       "filer_committee_id_number",
       "change_of_committee_name",
@@ -969,7 +969,7 @@
       "date_signed",
       "beginning_image_number"
     ],
-    "^8.4|8.3|8.2|8.1|8.0|7.0|6.4|6.3|6.2|6.1": [
+    "^8.5|8.4|8.3|8.2|8.1|8.0|7.0|6.4|6.3|6.2|6.1": [
       "form_type",
       "filer_committee_id_number",
       "committee_name",
@@ -1060,7 +1060,7 @@
       "memo_text_description",
       "image_number"
     ],
-    "^8.4|8.3|8.2|8.1|8.0|7.0|6.4|6.3|6.2|6.1": [
+    "^8.5|8.4|8.3|8.2|8.1|8.0|7.0|6.4|6.3|6.2|6.1": [
       "form_type",
       "filer_committee_id_number",
       "transaction_id_number",
@@ -1148,7 +1148,7 @@
       "memo_text_description",
       "image_number"
     ],
-    "^8.4|8.3|8.2|8.1|8.0|7.0|6.4|6.3|6.2|6.1": [
+    "^8.5|8.4|8.3|8.2|8.1|8.0|7.0|6.4|6.3|6.2|6.1": [
       "form_type",
       "filer_committee_id_number",
       "transaction_id_number",
@@ -1335,7 +1335,7 @@
       "date_signed",
       "beginning_image_number"
     ],
-    "^8.4|8.3|8.2|8.1|8.0|7.0|6.4|6.3|6.2|6.1": [
+    "^8.5|8.4|8.3|8.2|8.1|8.0|7.0|6.4|6.3|6.2|6.1": [
       "form_type",
       "filer_committee_id_number",
       "committee_name",
@@ -1558,6 +1558,45 @@
       "bank_state",
       "bank_zip_code",
       "beginning_image_number"
+    ],
+    "^8.5": [
+      "form_type",
+      "filer_committee_id_number",
+      "joint_fund_participant_committee_name",
+      "joint_fund_participant_committee_id_number",
+      "joint_fund_participant_committee_type",
+      "affiliated_committee_id_number",
+      "affiliated_committee_name",
+      "affiliated_candidate_id_number",
+      "affiliated_last_name",
+      "affiliated_first_name",
+      "affiliated_middle_name",
+      "affiliated_prefix",
+      "affiliated_suffix",
+      "affiliated_street_1",
+      "affiliated_street_2",
+      "affiliated_city",
+      "affiliated_state",
+      "affiliated_zip_code",
+      "affiliated_relationship_code",
+      "agent_last_name",
+      "agent_first_name",
+      "agent_middle_name",
+      "agent_prefix",
+      "agent_suffix",
+      "agent_street_1",
+      "agent_street_2",
+      "agent_city",
+      "agent_state",
+      "agent_zip_code",
+      "agent_title",
+      "agent_telephone",
+      "bank_name",
+      "bank_street_1",
+      "bank_street_2",
+      "bank_city",
+      "bank_state",
+      "bank_zip_code"
     ],
     "^8.4|8.3|8.2|8.1|8.0|7.0|6.4|6.3|6.2": [
       "form_type",
@@ -1799,7 +1838,7 @@
       "date_signed",
       "beginning_image_number"
     ],
-    "^8.4|8.3|8.2": [
+    "^8.5|8.4|8.3|8.2": [
       "form_type",
       "candidate_id_number",
       "candidate_last_name",
@@ -2040,7 +2079,7 @@
       "date_signed",
       "beginning_image_number"
     ],
-    "^8.4|8.3|8.2|8.1|8.0": [
+    "^8.5|8.4|8.3|8.2|8.1|8.0": [
       "form_type",
       "filer_committee_id_number",
       "report_type",
@@ -2402,7 +2441,7 @@
       "col_b_gross_receipts_minus_personal_funds_general",
       "beginning_image_number"
     ],
-    "^8.4|8.3|8.2|8.1|8.0|7.0|6.4": [
+    "^8.5|8.4|8.3|8.2|8.1|8.0|7.0|6.4": [
       "form_type",
       "filer_committee_id_number",
       "committee_name",
@@ -2868,7 +2907,7 @@
       "date_signed",
       "beginning_image_number"
     ],
-    "^8.4|8.3|8.2|8.1|8.0|7.0|6.4": [
+    "^8.5|8.4|8.3|8.2|8.1|8.0|7.0|6.4": [
       "form_type",
       "filer_committee_id_number",
       "committee_name",
@@ -3109,7 +3148,7 @@
       "end_image_number",
       "receipt_date"
     ],
-    "^8.4|8.3|8.2|8.1|8.0|7.0": [
+    "^8.5|8.4|8.3|8.2|8.1|8.0|7.0": [
       "form_type",
       "filer_committee_id_number",
       "committee_name",
@@ -3923,7 +3962,7 @@
     ]
   },
   "^f3p31": {
-    "^8.4|8.3|8.2|8.1|8.0|7.0|6.4|6.3|6.2|6.1": [
+    "^8.5|8.4|8.3|8.2|8.1|8.0|7.0|6.4|6.3|6.2|6.1": [
       "form_type",
       "filer_committee_id_number",
       "transaction_id_number",
@@ -4018,7 +4057,7 @@
     ]
   },
   "^f3ps": {
-    "^8.4|8.3|8.2|8.1|8.0|7.0": [
+    "^8.5|8.4|8.3|8.2|8.1|8.0|7.0": [
       "form_type",
       "filer_committee_id_number",
       "date_general_election",
@@ -4362,7 +4401,7 @@
       "total_disbursements",
       "beginning_image_number"
     ],
-    "^8.4|8.3|8.2|8.1|8.0|7.0|6.4|6.3|6.2|6.1": [
+    "^8.5|8.4|8.3|8.2|8.1|8.0|7.0|6.4|6.3|6.2|6.1": [
       "form_type",
       "filer_committee_id_number",
       "date_general_election",
@@ -4690,7 +4729,7 @@
       "col_b_net_operating_expenditures",
       "beginning_image_number"
     ],
-    "^8.4|8.3|8.2|8.1|8.0|7.0|6.4|6.3|6.2|6.1": [
+    "^8.5|8.4|8.3|8.2|8.1|8.0|7.0|6.4|6.3|6.2|6.1": [
       "form_type",
       "filer_committee_id_number",
       "committee_name",
@@ -5414,7 +5453,7 @@
       "col_b_total_disbursements",
       "beginning_image_number"
     ],
-    "^8.4|8.3|8.2|8.1|8.0|7.0|6.4|6.3|6.2|6.1": [
+    "^8.5|8.4|8.3|8.2|8.1|8.0|7.0|6.4|6.3|6.2|6.1": [
       "form_type",
       "filer_committee_id_number",
       "committee_name",
@@ -5716,7 +5755,7 @@
       "date_signed",
       "beginning_image_number"
     ],
-    "^(8.4|8.3|8.2|8.1)": [
+    "^(8.5|8.4|8.3|8.2|8.1)": [
       "form_type",
       "filer_committee_id_number",
       "entity_type",
@@ -5886,7 +5925,7 @@
       "contributor_occupation",
       "image_number"
     ],
-    "^8.4|8.3|8.2|8.1|8.0|7.0|6.4|6.3|6.2": [
+    "^8.5|8.4|8.3|8.2|8.1|8.0|7.0|6.4|6.3|6.2": [
       "form_type",
       "filer_committee_id_number",
       "transaction_id",
@@ -5971,7 +6010,7 @@
       "election_other_description",
       "image_number"
     ],
-    "^8.4|8.3|8.2|8.1": [
+    "^8.5|8.4|8.3|8.2|8.1": [
       "form_type",
       "filer_committee_id_number",
       "transaction_id_number",
@@ -6215,7 +6254,7 @@
       "date_signed",
       "beginning_image_number"
     ],
-    "^8.4|8.3|8.2|8.1|8.0": [
+    "^8.5|8.4|8.3|8.2|8.1|8.0": [
       "form_type",
       "filer_committee_id_number",
       "original_amendment_date",
@@ -6304,7 +6343,7 @@
       "contribution_amount",
       "image_number"
     ],
-    "^8.4|8.3|8.2|8.1|8.0|7.0|6.4|6.3|6.2|6.1": [
+    "^8.5|8.4|8.3|8.2|8.1|8.0|7.0|6.4|6.3|6.2|6.1": [
       "form_type",
       "filer_committee_id_number",
       "transaction_id",
@@ -6409,7 +6448,7 @@
       "date_signed",
       "beginning_image_number"
     ],
-    "^8.4|8.3|8.2|8.1|8.0|7.0|6.4|6.3|6.2|6.1": [
+    "^8.5|8.4|8.3|8.2|8.1|8.0|7.0|6.4|6.3|6.2|6.1": [
       "form_type",
       "filer_committee_id_number",
       "organization_name",
@@ -6475,7 +6514,7 @@
       "communication_cost",
       "image_number"
     ],
-    "^8.4|8.3|8.2|8.1|8.0|7.0|6.4|6.3|6.2|6.1": [
+    "^8.5|8.4|8.3|8.2|8.1|8.0|7.0|6.4|6.3|6.2|6.1": [
       "form_type",
       "filer_committee_id_number",
       "transaction_id",
@@ -6864,7 +6903,7 @@
       "date_signed",
       "beginning_image_number"
     ],
-    "^8.4|8.3": [
+    "^8.5|8.4|8.3": [
       "form_type",
       "filer_committee_id_number",
       "entity_type",
@@ -7052,7 +7091,7 @@
       "controller_occupation",
       "image_number"
     ],
-    "^8.4|8.3|8.2|8.1|8.0|7.0|6.4|6.3|6.2|6.1": [
+    "^8.5|8.4|8.3|8.2|8.1|8.0|7.0|6.4|6.3|6.2|6.1": [
       "form_type",
       "filer_committee_id_number",
       "transaction_id",
@@ -7118,7 +7157,7 @@
       "memo_text_description",
       "image_number"
     ],
-    "^8.4|8.3|8.2|8.1|8.0|7.0|6.4|6.3|6.2|6.1": [
+    "^8.5|8.4|8.3|8.2|8.1|8.0|7.0|6.4|6.3|6.2|6.1": [
       "form_type",
       "filer_committee_id_number",
       "transaction_id",
@@ -7306,7 +7345,7 @@
       "transaction_id",
       "image_number"
     ],
-    "^8.4|8.3|8.2|8.1|8.0|7.0|6.4|6.3|6.2|6.1": [
+    "^8.5|8.4|8.3|8.2|8.1|8.0|7.0|6.4|6.3|6.2|6.1": [
       "form_type",
       "filer_committee_id_number",
       "transaction_id",
@@ -7479,7 +7518,7 @@
       "back_reference_tran_id_number",
       "image_number"
     ],
-    "^8.4|8.3|8.2|8.1|8.0|7.0|6.4|6.3|6.2|6.1": [
+    "^8.5|8.4|8.3|8.2|8.1|8.0|7.0|6.4|6.3|6.2|6.1": [
       "form_type",
       "filer_committee_id_number",
       "transaction_id",
@@ -7520,6 +7559,26 @@
       "beginning_image_number",
       "end_image_number",
       "receipt_date"
+    ],
+    "^8.5": [
+      "form_type",
+      "filer_committee_id_number",
+      "committee_name",
+      "street_1",
+      "street_2",
+      "city",
+      "state",
+      "zip_code",
+      "treasurer_last_name",
+      "treasurer_first_name",
+      "treasurer_middle_name",
+      "treasurer_prefix",
+      "treasurer_suffix",
+      "date_signed",
+      "text_code",
+      "filing_frequency",
+      "pdf_attachment",
+      "text"
     ],
     "^8.4|8.3|8.2|8.1|8.0|7.0|6.4|6.3|6.2|6.1": [
       "form_type",
@@ -7696,7 +7755,7 @@
       "public_communications_referencing_party_ratio_applies",
       "image_number"
     ],
-    "^8.4|8.3|8.2": [
+    "^8.5|8.4|8.3|8.2": [
       "form_type",
       "filer_committee_id_number",
       "transaction_id",
@@ -7845,7 +7904,7 @@
       "nonfederal_percentage",
       "image_number"
     ],
-    "^8.4|8.3|8.2|8.1|8.0|7.0|6.4|6.3|6.2|6.1": [
+    "^8.5|8.4|8.3|8.2|8.1|8.0|7.0|6.4|6.3|6.2|6.1": [
       "form_type",
       "filer_committee_id_number",
       "transaction_id",
@@ -7895,7 +7954,7 @@
       "event_activity_name",
       "image_number"
     ],
-    "^8.4|8.3|8.2|8.1|8.0|7.0|6.4|6.3|6.2|6.1": [
+    "^8.5|8.4|8.3|8.2|8.1|8.0|7.0|6.4|6.3|6.2|6.1": [
       "form_type",
       "filer_committee_id_number",
       "transaction_id",
@@ -7998,7 +8057,7 @@
       "total_amount",
       "image_number"
     ],
-    "^8.4|8.3|8.2|8.1|8.0": [
+    "^8.5|8.4|8.3|8.2|8.1|8.0": [
       "form_type",
       "filer_committee_id_number",
       "transaction_id_number",
@@ -8250,7 +8309,7 @@
       "generic_campaign_amount",
       "image_number"
     ],
-    "^8.4|8.3|8.2|8.1|8.0|7.0|6.4|6.3|6.2|6.1": [
+    "^8.5|8.4|8.3|8.2|8.1|8.0|7.0|6.4|6.3|6.2|6.1": [
       "form_type",
       "filer_committee_id_number",
       "transaction_id",
@@ -8333,7 +8392,7 @@
       "total_amount",
       "image_number"
     ],
-    "^8.4|8.3|8.2|8.1|8.0": [
+    "^8.5|8.4|8.3|8.2|8.1|8.0": [
       "form_type",
       "filer_committee_id_number",
       "transaction_id_number",
@@ -8522,7 +8581,7 @@
       "increased_limit_code",
       "image_number"
     ],
-    "^8.4|8.3|8.2|8.1|8.0": [
+    "^8.5|8.4|8.3|8.2|8.1|8.0": [
       "form_type",
       "filer_committee_id_number",
       "transaction_id",
@@ -9005,7 +9064,7 @@
     ]
   },
   "^sa3l": {
-    "^8.4|8.3|8.2|8.1|8.0": [
+    "^8.5|8.4|8.3|8.2|8.1|8.0": [
       "form_type",
       "filer_committee_id_number",
       "transaction_id",
@@ -9269,7 +9328,7 @@
       "refund_or_disposal_of_excess",
       "image_number"
     ],
-    "^8.4|8.3|8.2|8.1|8.0": [
+    "^8.5|8.4|8.3|8.2|8.1|8.0": [
       "form_type",
       "filer_committee_id_number",
       "transaction_id_number",
@@ -9736,7 +9795,7 @@
       "secured",
       "image_number"
     ],
-    "^8.4|8.3|8.2|8.1|8.0|7.0|6.4|6.3|6.2": [
+    "^8.5|8.4|8.3|8.2|8.1|8.0|7.0|6.4|6.3|6.2": [
       "form_type",
       "filer_committee_id_number",
       "transaction_id_number",
@@ -9998,7 +10057,7 @@
       "authorized_date",
       "image_number"
     ],
-    "^8.4|8.3|8.2|8.1|8.0|7.0|6.4|6.3|6.2|6.1": [
+    "^8.5|8.4|8.3|8.2|8.1|8.0|7.0|6.4|6.3|6.2|6.1": [
       "form_type",
       "filer_committee_id_number",
       "transaction_id_number",
@@ -10235,7 +10294,29 @@
       "guaranteed_amount",
       "image_number"
     ],
-    "^8.4|8.3|8.2|8.1|8.0|7.0|6.4|6.3|6.2|6.1": [
+    "^8.5": [
+      "form_type",
+      "filer_committee_id_number",
+      "transaction_id_number",
+      "back_reference_tran_id_number",
+      "guarantor_entity",
+      "guarantor_organization_name",
+      "guarantor_committee_fec_id",
+      "guarantor_last_name",
+      "guarantor_first_name",
+      "guarantor_middle_name",
+      "guarantor_prefix",
+      "guarantor_suffix",
+      "guarantor_street_1",
+      "guarantor_street_2",
+      "guarantor_city",
+      "guarantor_state",
+      "guarantor_zip_code",
+      "guarantor_employer",
+      "guarantor_occupation",
+      "guaranteed_amount"
+    ],
+    "^8.5|8.4|8.3|8.2|8.1|8.0|7.0|6.4|6.3|6.2|6.1": [
       "form_type",
       "filer_committee_id_number",
       "transaction_id_number",
@@ -10319,7 +10400,7 @@
       "balance_at_close_this_period",
       "image_number"
     ],
-    "^8.4|8.3|8.2|8.1|8.0|7.0|6.4|6.3|6.2|6.1": [
+    "^8.5|8.4|8.3|8.2|8.1|8.0|7.0|6.4|6.3|6.2|6.1": [
       "form_type",
       "filer_committee_id_number",
       "transaction_id_number",
@@ -10537,7 +10618,7 @@
       "date_signed",
       "image_number"
     ],
-    "^8.4|8.3|8.2|8.1": [
+    "^8.5|8.4|8.3|8.2|8.1": [
       "form_type",
       "filer_committee_id_number",
       "transaction_id_number",
@@ -10996,7 +11077,7 @@
       "increased_limit",
       "image_number"
     ],
-    "^8.4|8.3|8.2|8.1|8.0": [
+    "^8.5|8.4|8.3|8.2|8.1|8.0": [
       "form_type",
       "filer_committee_id_number",
       "transaction_id_number",
@@ -11422,7 +11503,7 @@
       "col_b_cash_on_hand_close_of_period",
       "image_number"
     ],
-    "^8.4|8.3|8.2|8.1|8.0|7.0|6.4|6.3|6.2|6.1": [
+    "^8.5|8.4|8.3|8.2|8.1|8.0|7.0|6.4|6.3|6.2|6.1": [
       "form_type",
       "filer_committee_id_number",
       "transaction_id_number",
@@ -11510,7 +11591,7 @@
     ]
   },
   "^text": {
-    "^8.4|8.3|8.2|8.1|8.0|7.0|6.4|6.3|6.2|6.1": [
+    "^8.5|8.4|8.3|8.2|8.1|8.0|7.0|6.4|6.3|6.2|6.1": [
       "rec_type",
       "filer_committee_id_number",
       "transaction_id_number",

--- a/fecfile/mappings.json
+++ b/fecfile/mappings.json
@@ -10316,7 +10316,7 @@
       "guarantor_occupation",
       "guaranteed_amount"
     ],
-    "^8.5|8.4|8.3|8.2|8.1|8.0|7.0|6.4|6.3|6.2|6.1": [
+    "^8.4|8.3|8.2|8.1|8.0|7.0|6.4|6.3|6.2|6.1": [
       "form_type",
       "filer_committee_id_number",
       "transaction_id_number",


### PR DESCRIPTION
This is my best effort at updating to fec 8.5, based on [this updated specification](https://docquery.fec.gov/formatspecs/FEC_Format_v8.5.xlsx)

I have never used this repo, and do not consume data this way, so strongly recommend that someone who does use it try to use what I've done before approving/merging. I also think it's possible this will work now (since no 8.5 filings are coming through, and won't till at least Apr 28) but it will fail when it encounters an actual 8.5 filing.

The most questionable thing I did here is remove the f3z's (ie, I didn't include an entry for them in the JSON) because that filing type doesn't exist in the new spec. Review of others for typos etc probably a good idea, too.