### PR TITLE
Reverts exclusion of f3pz1 and f3pz2 for versions 8.4 and earlier

### DIFF
--- a/fecfile/mappings.json
+++ b/fecfile/mappings.json
@@ -2937,7 +2937,7 @@
       "date_signed"
     ]
   },
-  "(^f3p$)|(^f3p[^s|3|z])": {
+  "(^f3p$)|(^f3p[^s|3])": {
     "^P3.2|^P3.3|^P3.4": [
       "form_type",
       "filer_committee_id_number",


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Changes `"(^f3p$)|(^f3p[^s|3|z])"` to `"(^f3p$)|(^f3p[^s|3])"`, which matches version 0.8.0. 

You can test with filing id `1890417`

* **What is the current behavior?** (You can also link to an open issue here)

Parsing error for `f3pz` rows noted in https://github.com/esonderegger/fecfile/issues/44

* **What is the new behavior (if this is a feature change)?**

The parsing error is removed. However, it does not appear that there is a mapping specifically addressing `f3pz` files, so there are some type warnings generated on file read. I'm not sure if it matters at this point since version 8.5 does away with those.
